### PR TITLE
Add street vendor management tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,47 @@
-# Municipal Council Fuel Tracking
+# Municipal Council Data Tools
 
-This repository contains a simple command line application for tracking fuel usage for a municipal council fleet of 70 vehicles.
+This repository contains command line tools for municipal operations. The original tool `fuel_tracker.py` tracks fuel usage for a fleet of 70 vehicles.
 
-## Usage
+A new tool `vendor_tracker.py` manages information about licensed street vendors, tax payments and fines.
 
-```
+## Fuel Tracker Usage
+
+```bash
 python fuel_tracker.py add <vehicle_id> <amount>
 ```
-
 Adds a fuel entry for the specified vehicle.
 
-```
+```bash
 python fuel_tracker.py report
 ```
-
 Prints the total fuel used for each vehicle.
+Fuel data is stored in `fuel_data.json`.
 
-Fuel data is stored locally in `fuel_data.json`.
+## Vendor Tracker Usage
+
+```bash
+python vendor_tracker.py add_vendor <id> <name> <mobile> <area> [--photo PATH]
+```
+Registers a new street vendor.
+
+```bash
+python vendor_tracker.py add_tax <id> <amount>
+```
+Records a tax payment for the vendor.
+
+```bash
+python vendor_tracker.py add_fine <id> <amount> <reason>
+```
+Records a spot fine for the vendor.
+
+```bash
+python vendor_tracker.py report
+```
+Shows a summary of vendors with total taxes and fines.
+
+```bash
+python vendor_tracker.py qr <id>
+```
+Prints a QR data string that encodes the vendor's basic information.
+
+Vendor data is stored in `vendor_data.json`.

--- a/vendor_tracker.py
+++ b/vendor_tracker.py
@@ -1,0 +1,129 @@
+import json
+import os
+from datetime import datetime
+import argparse
+import base64
+
+DATA_FILE = 'vendor_data.json'
+
+
+def load_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    return {'vendors': {}}
+
+
+def save_data(data):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def add_vendor(vendor_id, name, mobile, area, photo):
+    data = load_data()
+    if vendor_id in data['vendors']:
+        print(f"Vendor {vendor_id} already exists")
+        return
+    data['vendors'][vendor_id] = {
+        'name': name,
+        'mobile': mobile,
+        'area': area,
+        'photo': photo,
+        'taxes': [],
+        'fines': []
+    }
+    save_data(data)
+    print(f"Added vendor {vendor_id} - {name}")
+
+
+def add_tax(vendor_id, amount):
+    data = load_data()
+    vendor = data['vendors'].get(vendor_id)
+    if vendor is None:
+        print(f"Vendor {vendor_id} not found")
+        return
+    vendor['taxes'].append({
+        'date': datetime.now().isoformat(timespec='seconds'),
+        'amount': amount
+    })
+    save_data(data)
+    print(f"Added tax record for vendor {vendor_id}")
+
+
+def add_fine(vendor_id, amount, reason):
+    data = load_data()
+    vendor = data['vendors'].get(vendor_id)
+    if vendor is None:
+        print(f"Vendor {vendor_id} not found")
+        return
+    vendor['fines'].append({
+        'date': datetime.now().isoformat(timespec='seconds'),
+        'amount': amount,
+        'reason': reason
+    })
+    save_data(data)
+    print(f"Added fine for vendor {vendor_id}")
+
+
+def qr_string(vendor_id):
+    data = load_data()
+    vendor = data['vendors'].get(vendor_id)
+    if vendor is None:
+        print(f"Vendor {vendor_id} not found")
+        return
+    info = json.dumps({
+        'id': vendor_id,
+        'name': vendor['name'],
+        'mobile': vendor['mobile'],
+        'area': vendor['area']
+    })
+    encoded = base64.urlsafe_b64encode(info.encode()).decode()
+    print(encoded)
+
+
+def report():
+    data = load_data()
+    for vid, vinfo in data['vendors'].items():
+        total_tax = sum(t['amount'] for t in vinfo['taxes'])
+        total_fine = sum(f['amount'] for f in vinfo['fines'])
+        print(f"Vendor {vid}: {vinfo['name']} - Area: {vinfo['area']} - Taxes: {total_tax} - Fines: {total_fine}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Street Vendor Management')
+    sub = parser.add_subparsers(dest='command')
+
+    av = sub.add_parser('add_vendor', help='Add a new vendor')
+    av.add_argument('vendor_id')
+    av.add_argument('name')
+    av.add_argument('mobile')
+    av.add_argument('area')
+    av.add_argument('--photo', default='')
+
+    tax = sub.add_parser('add_tax', help='Record tax payment')
+    tax.add_argument('vendor_id')
+    tax.add_argument('amount', type=float)
+
+    fine = sub.add_parser('add_fine', help='Record fine')
+    fine.add_argument('vendor_id')
+    fine.add_argument('amount', type=float)
+    fine.add_argument('reason')
+
+    sub.add_parser('report', help='Show vendor report')
+
+    qr = sub.add_parser('qr', help='Show vendor QR data string')
+    qr.add_argument('vendor_id')
+
+    args = parser.parse_args()
+    if args.command == 'add_vendor':
+        add_vendor(args.vendor_id, args.name, args.mobile, args.area, args.photo)
+    elif args.command == 'add_tax':
+        add_tax(args.vendor_id, args.amount)
+    elif args.command == 'add_fine':
+        add_fine(args.vendor_id, args.amount, args.reason)
+    elif args.command == 'report':
+        report()
+    elif args.command == 'qr':
+        qr_string(args.vendor_id)
+    else:
+        parser.print_help()


### PR DESCRIPTION
## Summary
- extend README with vendor tracker instructions
- add `vendor_tracker.py` for managing street vendors

## Testing
- `python -m py_compile fuel_tracker.py vendor_tracker.py`
- `python vendor_tracker.py add_vendor 1 "John Doe" 1234567890 Downtown --photo john.jpg`
- `python vendor_tracker.py add_tax 1 50`
- `python vendor_tracker.py add_fine 1 20 Littering`
- `python vendor_tracker.py report`
- `python vendor_tracker.py qr 1`

------
https://chatgpt.com/codex/tasks/task_e_687b655809d8833286cf2db158ed3caf